### PR TITLE
Fix broken links to global attributes section in overview

### DIFF
--- a/src/docs/004-elements/005-typography.md
+++ b/src/docs/004-elements/005-typography.md
@@ -3,7 +3,7 @@ title: Typography
 description: Use the same HTML markup in HEML for your typography
 ---
 
-When writing your content, use the same HTML markup tags you are accustomed to. It is important to note that HEML bundles fixes for common issues with these tags so you are free to use them safely in email. They all support the [global attributes](/elements/overview#global-attributes).
+When writing your content, use the same HTML markup tags you are accustomed to. It is important to note that HEML bundles fixes for common issues with these tags so you are free to use them safely in email. They all support the [global attributes](/docs/elements/overview#global-attributes).
 
 All text should be in a header, paragraph, or list for your styling to work as expected.
 

--- a/src/docs/004-elements/006-block.md
+++ b/src/docs/004-elements/006-block.md
@@ -34,7 +34,7 @@ The block element is useful for a safe way to add a generic block element into y
 
 ## Attributes
 
-This element supports the [global attributes](/elements/overview#global-attributes).
+This element supports the [global attributes](/docs/elements/overview#global-attributes).
 
 ## Styling
 

--- a/src/docs/004-elements/007-image.md
+++ b/src/docs/004-elements/007-image.md
@@ -7,7 +7,7 @@ Images are a powerful tool in your emails. However, they are widely misused. You
 
 ## Examples
 
-### Basic image 
+### Basic image
 
 ```xml
 <img src="http://example.com/my-image.jpg" alt="my image" width="100" />
@@ -29,7 +29,7 @@ If you are using a retina sized image you can set `infer=retina` which will set 
 
 ## Attributes
 
-This element supports the [global attributes](/elements/overview#global-attributes).
+This element supports the [global attributes](/docs/elements/overview#global-attributes).
 
 <div class="attributes-table">
 

--- a/src/docs/004-elements/008-button.md
+++ b/src/docs/004-elements/008-button.md
@@ -39,7 +39,7 @@ description: "Use the button element to add a button-styled link."
 
 ## Attributes
 
-This element supports the [global attributes](/elements/overview#global-attributes).
+This element supports the [global attributes](/docs/elements/overview#global-attributes).
 
 <div class="attributes-table">
 

--- a/src/docs/004-elements/09-link.md
+++ b/src/docs/004-elements/09-link.md
@@ -14,7 +14,7 @@ description: Use the <a> element to add a link to another page or a section in t
 
 ## Attributes
 
-This element supports the [global attributes](/elements/overview#global-attributes).
+This element supports the [global attributes](/docs/elements/overview#global-attributes).
 
 <div class="attributes-table">
 


### PR DESCRIPTION
Bug originally filed in [heml #81](https://github.com/SparkPost/heml/issues/81).

Simple change to add `/docs` to the beginning of links where it is missing.